### PR TITLE
additional path type for win32 / xfce

### DIFF
--- a/lib/bridge/xfce.sh
+++ b/lib/bridge/xfce.sh
@@ -1,0 +1,13 @@
+#http://askubuntu.com/questions/414422/command-to-change-the-wallpaper-in-xubuntu
+
+connectedOutputs=$(xrandr | grep " connected" | sed -e "s/\([A-Z0-9]\+\) connected.*/\1/")
+activeOutput=$(xrandr | grep -e " connected [^(]" | sed -e "s/\([A-Z0-9]\+\) connected.*/\1/") 
+connected=$(echo $connectedOutputs | wc -w)
+
+xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/image-path -n -t string -s  $1
+xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitorLVDS1/workspace0/last-image -n -t string -s  $1
+
+for i in $(xfconf-query -c xfce4-desktop -p /backdrop -l|egrep -e "screen.*/monitor.*image-path$" -e "screen.*/monitor.*/last-image$"); do
+    xfconf-query -c xfce4-desktop -p $i -n -t string -s $1 
+    xfconf-query -c xfce4-desktop -p $i -s $1
+done

--- a/lib/platforms/win32.js
+++ b/lib/platforms/win32.js
@@ -4,42 +4,55 @@ var shell = require('shelljs');
 var log4js = require('log4js');
 
 var logger = log4js.getLogger('wallpaper');
-var WIN32_WALLPAPER_SETTER = '../bridge/wallpaper.exe';
+var WIN32_WALLPAPER_SETTERS = [
+  '../bridge/wallpaper.exe',
+  '..\\bridge\\wallpaper.exe'
+];
 
 exports.set = function (options, callback) {
-  var command = WIN32_WALLPAPER_SETTER
-    + ' ' + options.file
-    + ' ' + options.style;
+  WIN32_WALLPAPER_SETTERS.some(function (setter) {
+    var command = setter
+      + ' ' + options.file
+      + ' ' + options.style;
+    var found;
 
-  shell.exec(command, function (code, output) {
-    switch (code) {
-      case 0:
-        if (typeof callback != 'undefined') {
-          callback(true);
-        }
-        break;
-      case -1:
-        logger.fatal('invalid parameters');
-        logger.fatal(output);
-        process.exit(-1);
-        break;
-      case -2:
-        logger.fatal('doesn\'t support JPG file. The .jpg wallpapers are not supported before Windows Vista.');
-        logger.fatal('please use .bmp instead.');
-        process.exit(-1);
-        break;
-      case -3:
-        logger.fatal('doesn\'t support Fit or Fill style. The styles are not supported before Windows 7.');
-        logger.fatal('please use other styles instead.');
-        process.exit(-1);
-        break;
-      case -4:
-        logger.fatal('cannot set wallpaper for your System.');
-        process.exit(-1);
-        break;
-      default:
-        break;
-    }
+    shell.exec(command, function (code, output) {
+
+      found = true;
+
+      switch (code) {
+        case 0:
+          if (typeof callback != 'undefined') {
+            callback(true);
+          }
+          break;
+        case -1:
+          logger.fatal('invalid parameters');
+          logger.fatal(output);
+          process.exit(-1);
+          break;
+        case -2:
+          logger.fatal('doesn\'t support JPG file. The .jpg wallpapers are not supported before Windows Vista.');
+          logger.fatal('please use .bmp instead.');
+          process.exit(-1);
+          break;
+        case -3:
+          logger.fatal('doesn\'t support Fit or Fill style. The styles are not supported before Windows 7.');
+          logger.fatal('please use other styles instead.');
+          process.exit(-1);
+          break;
+        case -4:
+          logger.fatal('cannot set wallpaper for your System.');
+          process.exit(-1);
+          break;
+        case 1:
+          found = false;
+          break;
+      }
+
+    });
+
+    return found;
   });
 };
 


### PR DESCRIPTION
This basically adds another win32 path type. The second path will only be tried if the first path fails (which means the code from shell would be 1).
