### PR TITLE
pass all options to platform handler

### DIFF
--- a/lib/wallpaper.js
+++ b/lib/wallpaper.js
@@ -15,8 +15,8 @@ function checkAccess(file) {
   return file;
 }
 
-function setWallpaper(file, callback) {
-  platform.set({file: file})
+function setWallpaper(options, callback) {
+  platform.set(options)
     .then(function () {
       callback && callback();
     })
@@ -37,6 +37,8 @@ exports.set = function (options, callback) {
     // 3. set wallpaper
     .then(function (file) {
       logger.info('setting wallpaper: ', file);
-      setWallpaper(file, callback);
+      delete options.source;
+      options.file = file;
+      setWallpaper(options, callback);
     });
 };


### PR DESCRIPTION
Right now I can't use the style option for Windows wallpaper because that option is never passed to the wallpaper.exe. wallpaper.js ignores all options and only passes the file parameter. Here's a fix that uses every (future) option.
